### PR TITLE
Fix invalid self-closing <span /> tags incompatible with jQuery 3.5

### DIFF
--- a/src/spectrum.js
+++ b/src/spectrum.js
@@ -151,9 +151,9 @@
                 c += (tinycolor.equals(color, current)) ? " sp-thumb-active" : "";
                 var formattedString = tiny.toString(opts.preferredFormat || "rgb");
                 var swatchStyle = rgbaSupport ? ("background-color:" + tiny.toRgbString()) : "filter:" + tiny.toFilter();
-                html.push('<span title="' + formattedString + '" data-color="' + tiny.toRgbString() + '" class="' + c + '"><span class="sp-thumb-inner" style="' + swatchStyle + ';" /></span>');
+                html.push('<span title="' + formattedString + '" data-color="' + tiny.toRgbString() + '" class="' + c + '"><span class="sp-thumb-inner" style="' + swatchStyle + ';"></span></span>');
             } else {
-                html.push('<span class="sp-thumb-el sp-clear-display" ><span class="sp-clear-palette-only" style="background-color: transparent;" /></span>');
+                html.push('<span class="sp-thumb-el sp-clear-display" ><span class="sp-clear-palette-only" style="background-color: transparent;"></span></span>');
             }
         }
         return "<div class='sp-cf " + className + "'>" + html.join('') + "</div>";


### PR DESCRIPTION
To close a cross-site scripting vulnerability, jQuery 3.5.0 disabled an insecure `htmlPrefilter` that previously fixed up invalid self-closing tags. Fix our HTML not to rely on that.

https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/

(Upstream PR: bgrins#556)